### PR TITLE
A-Assertions: Add assertions to Dyuque, Parser, TaskList

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,4 +53,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/dyuque/Dyuque.java
+++ b/src/main/java/dyuque/Dyuque.java
@@ -48,7 +48,7 @@ public class Dyuque {
          * @param keyword Keyword to resolve into a command.
          * @return Matching command if the keyword is recognized.
          */
-        protected static Optional<Command> get(String keyword) {
+        protected static Optional<Command> getCommand(String keyword) {
             for (Command command : values()) {
                 if (command.keywords.contains(keyword)) {
                     return Optional.of((command));
@@ -123,15 +123,21 @@ public class Dyuque {
      */
     public String executeCommand(String input) throws DyuqueException {
         ui.showLine();
-        CommandArgumentPair commandArgumentPair = parser.parseCommand(input);
-        Command command = commandArgumentPair.command();
-        String[] arguments = commandArgumentPair.argument();
+
+        CommandArgumentPair pair = parser.parseCommand(input);
+
+        Command command = pair.command();
+        assert command != null : "Parser returned null command";
+
+        String[] arguments = pair.argument();
+        assert arguments != null : "Parser returned null arguments";
         /*  Elements of arguments:
                 delete/mark/unmark: index
                 to-do:              description
                 deadline:           description, dueDate
                 event:              description, fromDate, toDate
          */
+
         try {
             return switch (command) {
                 case Exit -> {

--- a/src/main/java/dyuque/Parser.java
+++ b/src/main/java/dyuque/Parser.java
@@ -18,11 +18,13 @@ public class Parser {
             throw new DyuqueException("Please enter a command");
         }
 
-        String[] commandAndArguments = input.trim().split(" ", 2); /* Splits "deadline return book /by Sunday"
-                                                               into ["deadline", "return book /by Sunday"] */
+        // Splits "deadline return book /by Sunday" into ["deadline", "return book /by Sunday"]
+        String[] commandAndArguments = input.trim().split(" ", 2);
+        assert commandAndArguments.length >= 1 : "Split should always produce at least one element";
+
         String commandStr = commandAndArguments[0];
         Dyuque.Command command = Dyuque.Command
-                .get(commandStr)
+                .getCommand(commandStr)
                 .orElseThrow(() -> new DyuqueException("Unknown command: " + commandStr));
         String arguments = (commandAndArguments.length == 2)
                 ? commandAndArguments[1].trim()

--- a/src/main/java/dyuque/TaskList.java
+++ b/src/main/java/dyuque/TaskList.java
@@ -54,9 +54,8 @@ public class TaskList {
      *
      * @param keyword Keyword to search for within task descriptions.
      * @return User-facing list of matching tasks.
-     * @throws DyuqueException If the keyword is blank.
      */
-    public String find(String keyword) throws DyuqueException {
+    public String find(String keyword) {
         String needle = keyword.trim().toLowerCase();
         StringBuilder output = new StringBuilder();
         int matchCount = 0;
@@ -84,7 +83,10 @@ public class TaskList {
      * @throws DyuqueException If the task list cannot be saved.
      */
     public String add(Task task) throws DyuqueException {
+        int previousSize = size();
         items.add(task);
+        assert size() == previousSize + 1 : "Task list size should increase after adding";
+
         saveIfEnabled();
 
         StringBuilder output = new StringBuilder();
@@ -95,7 +97,6 @@ public class TaskList {
                 .append(size())
                 .append(") tasks.")
                 .append(System.lineSeparator());
-
         return output.toString();
     }
 
@@ -107,8 +108,12 @@ public class TaskList {
      * @throws DyuqueException If the index is invalid or the task list cannot be saved.
      */
     public String delete(int arrayIndex) throws DyuqueException {
-        Task removed = get(arrayIndex);  // validate once
+        Task removed = getTask(arrayIndex);
+
+        int previousSize = size();
         items.remove(arrayIndex);
+        assert previousSize == size() - 1 : "Task list size should decrease after deleting";
+
         saveIfEnabled();
 
         StringBuilder output = new StringBuilder();
@@ -119,7 +124,6 @@ public class TaskList {
                 .append(size())
                 .append(") tasks.")
                 .append(System.lineSeparator());
-
         return output.toString();
     }
 
@@ -132,8 +136,7 @@ public class TaskList {
      * @throws DyuqueException If the index is invalid or the task list cannot be saved.
      */
     protected String setMarkedState(markedState state, int arrayIndex) throws DyuqueException {
-        // arrayIndex is 0-based
-        Task task = get(arrayIndex);
+        Task task = getTask(arrayIndex);
 
         String message = switch (state) {
             case Marked -> {
@@ -152,16 +155,8 @@ public class TaskList {
                 + task + System.lineSeparator();
     }
 
-    private int size() {
-        return items.size();
-    }
-
-    private Task get(int arrayIndex) throws DyuqueException {
-        // arrayIndex is 0-based
-
-        if (arrayIndex < 0 || (arrayIndex + 1) > size()) {
-            throw new DyuqueException("dyuque.Task " + (arrayIndex + 1) + " does not exist.\nThere are only " + size() + " tasks");
-        }
+    private Task getTask(int arrayIndex) throws DyuqueException {
+        validateIndexBounds(arrayIndex);
         return items.get(arrayIndex);
     }
 
@@ -169,5 +164,16 @@ public class TaskList {
         if (storage != null) {
             storage.save(items);
         }
+    }
+
+    private void validateIndexBounds(int arrayIndex) throws DyuqueException {
+        // arrayIndex is 0-based
+        if (arrayIndex < 0 || arrayIndex >= size()) {
+            throw new DyuqueException("dyuque.Task " + (arrayIndex + 1) + " does not exist.\nThere are only " + size() + " tasks");
+        }
+    }
+
+    private int size() {
+        return items.size();
     }
 }


### PR DESCRIPTION
Dyuque, Parser, and TaskList rely on several internal invariants and assumptions regarding data integrity and object state.

Undetected violations of these assumptions can lead to inconsistent behavior or difficult-to-trace bugs. Relying solely on manual testing may allow logic errors to persist in the codebase.

Let's add Java assertions to:
- verify that Parser produces valid commands and arguments for Dyuque
- validate that TaskList operations correctly increment sizes

Assertions are used instead of standard exceptions because these checks address internal logic errors rather than recoverable user input errors. This approach provides a lightweight way to document and enforce developer assumptions during the testing phase.