### PR TITLE
C-Undo: Add undo feature using inverse-action stack

### DIFF
--- a/src/main/java/dyuque/Deadline.java
+++ b/src/main/java/dyuque/Deadline.java
@@ -22,19 +22,15 @@ public class Deadline extends Task {
      */
     public Deadline(String description, String dueDate) throws DyuqueException {
         super(description);
-        this.dueDate = parseIsoDate(dueDate, "deadline /by");
+        this.dueDate = parseIsoDate(dueDate);
     }
 
-    public LocalDate getDueDate() {
-        return this.dueDate;
-    }
-
-    private static LocalDate parseIsoDate(String dueDateStr, String field) throws DyuqueException {
+    private static LocalDate parseIsoDate(String dueDateStr) throws DyuqueException {
         try {
             return LocalDate.parse(dueDateStr); // ISO-8601: yyyy-MM-dd
         } catch (DateTimeParseException e) {
             throw new DyuqueException(
-                    "Invalid date format for " + field + ". Please use YYYY-MM-DD (e.g., 2026-12-30).",
+                    "Invalid date format for deadline /by. Please use YYYY-MM-DD (e.g., 2026-12-30).",
                     e
             );
         }
@@ -46,7 +42,7 @@ public class Deadline extends Task {
     @Override
     public String toString() {
         return "[D]"
-                + (isDone ? "[X] " : "[ ] ")
+                + (state.equals(State.MARKED) ? "[X] " : "[ ] ")
                 + description
                 + " (by: " + dueDate.format(OUTPUT_FORMAT) + ")";
     }

--- a/src/main/java/dyuque/Dyuque.java
+++ b/src/main/java/dyuque/Dyuque.java
@@ -1,5 +1,7 @@
 package dyuque;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -19,6 +21,8 @@ public class Dyuque {
     private final Parser parser;
     /** In-memory list of tasks managed by the chatbot. */
     private final TaskList taskList;
+    /** Stack of UndoActions to support undo command */
+    private final Deque<UndoAction> undoStack = new ArrayDeque<>();
     /** Whether the main chat loop should continue executing. */
     private boolean shouldContinueExecution;
 
@@ -43,7 +47,9 @@ public class Dyuque {
         UNMARK("unmark <index>",
                 "unmark"),
         EXIT("exit",
-                "bye", "exit");
+                "bye", "exit"),
+        UNDO("undo",
+                "undo");
 
         /** User-facing help string to use the command. */
         private final String usageHelpStr;
@@ -79,6 +85,11 @@ public class Dyuque {
             }
             return Optional.empty();
         }
+    }
+
+    @FunctionalInterface
+    private interface UndoAction {
+        String undo() throws DyuqueException;
     }
 
     /** Package-private constructor for test classes */
@@ -174,12 +185,17 @@ public class Dyuque {
             case EXIT -> handleExit();
             case LIST -> handleList();
             case FIND -> handleFind(arguments[0]);
+
             case TODO -> handleAddTask(new Todo(arguments[0]));
             case DEADLINE -> handleAddTask(new Deadline(arguments[0], arguments[1]));
             case EVENT -> handleAddTask(new Event(arguments[0], arguments[1], arguments[2]));
+
             case DELETE -> handleDeleteTask(arguments[0]);
+
             case MARK -> handleMarkTask(arguments[0]);
             case UNMARK -> handleUnmarkTask(arguments[0]);
+
+            case UNDO -> handleUndo();
         };
     }
 
@@ -200,25 +216,55 @@ public class Dyuque {
 
     private String handleAddTask(Task task) throws DyuqueException {
         Task addedTask = taskList.add(task);
+        int addedIndex = taskList.size() - 1;
+
+        undoStack.push(() -> {
+            Task deletedTask = taskList.delete(addedIndex);
+            return ui.formatTaskDeleted(deletedTask, taskList.size());
+        });
+
         return ui.formatTaskAdded(addedTask, taskList.size());
     }
 
     private String handleDeleteTask(String indexStr) throws DyuqueException {
         int index = parseTaskIndex(indexStr);
         Task deletedTask = taskList.delete(index);
+
+        undoStack.push(() -> {
+            taskList.add(index, deletedTask);
+            return ui.formatTaskAdded(deletedTask, taskList.size());
+        });
+
         return ui.formatTaskDeleted(deletedTask, taskList.size());
     }
 
     private String handleMarkTask(String indexStr) throws DyuqueException {
-        int index = parseTaskIndex(indexStr);
-        Task markedTask = taskList.setMarkedState(TaskList.MarkedState.MARKED, index);
-        return ui.formatTaskMarked(markedTask);
+        return processStateChange(indexStr, Task.State.MARKED);
     }
 
     private String handleUnmarkTask(String indexStr) throws DyuqueException {
+        return processStateChange(indexStr, Task.State.UNMARKED);
+    }
+
+    private String processStateChange(String indexStr, Task.State newState) throws DyuqueException {
         int index = parseTaskIndex(indexStr);
-        Task unmarkedTask = taskList.setMarkedState(TaskList.MarkedState.UNMARKED, index);
-        return ui.formatTaskUnmarked(unmarkedTask);
+        Task.State previousTaskState = taskList.getTaskState(index);
+
+        Task updatedTask = taskList.setMarkedState(newState, index);
+
+        undoStack.push(() -> {
+            Task restoredTask = taskList.setMarkedState(previousTaskState, index);
+            return ui.formatTaskChangedState(restoredTask, previousTaskState);
+        });
+
+        return ui.formatTaskChangedState(updatedTask, newState);
+    }
+
+    private String handleUndo() throws DyuqueException {
+        if (undoStack.isEmpty()) {
+            return ui.showError("Nothing to undo.");
+        }
+        return undoStack.pop().undo();
     }
 
     private int parseTaskIndex(String indexStr) throws DyuqueException {
@@ -233,7 +279,7 @@ public class Dyuque {
         return ui.showWelcome();
     }
 
-    Boolean getShouldContinueExecution() {
+    boolean getShouldContinueExecution() {
         return shouldContinueExecution;
     }
 }

--- a/src/main/java/dyuque/Event.java
+++ b/src/main/java/dyuque/Event.java
@@ -49,7 +49,7 @@ public class Event extends Task{
     @Override
     public String toString() {
         return "[E]"
-                + (isDone ? "[X] " : "[ ] ")
+                + (state.equals(State.MARKED) ? "[X] " : "[ ] ")
                 + description
                 + " (from: " + fromDate.format(OUTPUT_FORMAT) + ")"
                 + " (to: " + toDate.format(OUTPUT_FORMAT) + ")";

--- a/src/main/java/dyuque/Parser.java
+++ b/src/main/java/dyuque/Parser.java
@@ -4,6 +4,8 @@ package dyuque;
  * Parses user input strings into commands and structured arguments.
  */
 public class Parser {
+    // Class inspired from multiple LLMs including ChatGPT, Claude, and Google AI
+
     /**
      * Returns a command-argument pair parsed from the specified user input.
      *
@@ -12,7 +14,6 @@ public class Parser {
      * @throws DyuqueException If the input is blank, the command is unknown, or the command usage is invalid.
      */
     public CommandArgumentPair parseCommand(String input) throws DyuqueException {
-        // Method inspired from multiple LLMs including ChatGPT, Claude, and Google AI
         validateNotBlank(input);
 
         // Splits "deadline return book /by Sunday" into ["deadline", "return book /by Sunday"]
@@ -45,7 +46,7 @@ public class Parser {
 
     private CommandArgumentPair parseCommandArguments(Dyuque.Command command, String arguments) throws DyuqueException {
         return switch (command) {
-            case EXIT, LIST -> new CommandArgumentPair(command, new String[0]);
+            case EXIT, LIST, UNDO -> new CommandArgumentPair(command, new String[0]);
             case DELETE, MARK, UNMARK, FIND, TODO -> parseSingleArgCommand(command, arguments);
             case EVENT -> parseEventCommand(command, arguments);
             case DEADLINE -> parseDeadlineCommand(command, arguments);

--- a/src/main/java/dyuque/Storage.java
+++ b/src/main/java/dyuque/Storage.java
@@ -126,9 +126,9 @@ public class Storage {
 
         // set task doneState
         if ("1".equals(doneState)) {
-            task.markDone();
+            task.setState(Task.State.MARKED);
         } else if ("0".equals(doneState)) {
-            task.markUndone();
+            task.setState(Task.State.UNMARKED);
         } else {
             throw new DyuqueException("Invalid done flag in line:\n  " + line);
         }

--- a/src/main/java/dyuque/Task.java
+++ b/src/main/java/dyuque/Task.java
@@ -3,8 +3,18 @@ package dyuque;
 public abstract class Task {
     /** Description of the task. */
     protected String description;
-    /** Whether the task is marked as done. */
-    protected Boolean isDone;
+    /** Whether the task state is marked or unmarked. */
+    protected State state;
+
+    /**
+     * Represents the state of a task.
+     */
+    public enum State {
+        /** The task is finished and will be shown as such. */
+        MARKED,
+        /** The task is still pending and requires action. */
+        UNMARKED
+    }
 
     /**
      * Creates a task with the specified description.
@@ -13,32 +23,35 @@ public abstract class Task {
      */
     public Task(String description) {
         this.description = description;
-        this.isDone = false;
+        this.state = State.UNMARKED;
     }
 
     /**
-     * Marks this task as completed.
+     * Sets the task's state.
      */
-    public void markDone() {
-        this.isDone = true;
+    public void setState(State state) {
+        this.state = state;
     }
 
     /**
-     * Marks this task as not completed.
+     * Returns the task description.
      */
-    public void markUndone() {
-        this.isDone = false;
-    }
-
     public String getDescription() {
         return this.description;
+    }
+
+    /**
+     * Returns the task state.
+     */
+    public State getState() {
+        return this.state;
     }
 
     /**
      * Returns the storage flag representing whether this task is done.
      */
     protected String doneFlag() {
-        return isDone ? "1" : "0";
+        return state.equals(State.MARKED) ? "1" : "0";
     }
 
     /**

--- a/src/main/java/dyuque/TaskList.java
+++ b/src/main/java/dyuque/TaskList.java
@@ -13,14 +13,6 @@ public class TaskList {
     private final Storage storage;
 
     /**
-     * Represents the completion state to apply when marking or unmarking a task.
-     */
-    public enum MarkedState {
-        MARKED,
-        UNMARKED
-    }
-
-    /**
      * Creates a task list with the specified initial items and storage handler.
      *
      * @param initialItems Initial tasks to manage.
@@ -77,6 +69,23 @@ public class TaskList {
     }
 
     /**
+     * Adds the specified task at a specific index to this task list.
+     *
+     * @param index Index of task to add.
+     * @param task Task to add.
+     * @return The added task.
+     * @throws DyuqueException If the task list cannot be saved.
+     */
+    public Task add(int index, Task task) throws DyuqueException {
+        int previousSize = size();
+        items.add(index - 1, task);
+        assert size() == previousSize + 1 : "Task list size should increase after adding";
+
+        saveIfEnabled();
+        return task;
+    }
+
+    /**
      * Deletes the task at the specified 0-based index.
      *
      * @param arrayIndex 0-based index of the task to delete.
@@ -102,16 +111,22 @@ public class TaskList {
      * @return The updated task.
      * @throws DyuqueException If the index is invalid or the task list cannot be saved.
      */
-    public Task setMarkedState(MarkedState state, int arrayIndex) throws DyuqueException {
+    public Task setMarkedState(Task.State state, int arrayIndex) throws DyuqueException {
         Task task = getTask(arrayIndex);
-
-        switch (state) {
-            case MARKED -> task.markDone();
-            case UNMARKED -> task.markUndone();
-        }
-
+        task.setState(state);
         saveIfEnabled();
         return task;
+    }
+
+    /**
+     * Gets the marked state of the task at the specified 0-based index.
+     *
+     * @param arrayIndex 0-based index of the task to update.
+     * @return The task state.
+     * @throws DyuqueException If the index is invalid or the task list cannot be saved.
+     */
+    public Task.State getTaskState(int arrayIndex) throws DyuqueException {
+        return getTask(arrayIndex).getState();
     }
 
     /**

--- a/src/main/java/dyuque/Todo.java
+++ b/src/main/java/dyuque/Todo.java
@@ -20,7 +20,7 @@ public class Todo extends Task {
     @Override
     public String toString() {
         return "[T]"
-                + (isDone ? "[X] " : "[ ] ")
+                + (state.equals(State.MARKED) ? "[X] " : "[ ] ")
                 + description;
     }
 

--- a/src/main/java/dyuque/Ui.java
+++ b/src/main/java/dyuque/Ui.java
@@ -63,6 +63,7 @@ public class Ui {
                   "unmark" - unmark a task as done
                              unmark <task number>
                   "bye" ---- quit Dyuque
+                  "undo" --- undo previous state change
                 Task types:
                   todo ----- "todo <description>"
                   deadline - "deadline <description> /by <YYYY-MM-DD>"
@@ -83,16 +84,6 @@ public class Ui {
         System.out.println(message);
         return message;
     }
-
-//    /**
-//     * Prints the specified message without adding extra formatting.
-//     *
-//     * @param message Message to print.
-//     */
-//    public String showMessage(String message) {
-//        System.out.print(message);
-//        return message;
-//    }
 
     /**
      * Formats and displays a list of tasks.
@@ -160,35 +151,23 @@ public class Ui {
     }
 
     /**
-     * Formats and displays a task marked as done.
+     * Formats and displays a task's state change.
      *
-     * @param markedTask The task that was marked.
+     * @param task The task that was marked.
      * @return Formatted message.
      */
-    public String formatTaskMarked(Task markedTask) {
-        String message = "Nice! I've marked this task as done:"
-                + System.lineSeparator()
-                + markedTask
-                + System.lineSeparator();
+    public String formatTaskChangedState(Task task, Task.State state) {
+        StringBuilder message = new StringBuilder();
+        switch (state) {
+            case MARKED -> message.append("Nice! I've marked this task as done:");
+            case UNMARKED -> message.append("OK, I've marked this task as not done yet:");
+        }
+        message.append(System.lineSeparator())
+                .append(task)
+                .append(System.lineSeparator());
 
         System.out.print(message);
-        return message;
-    }
-
-    /**
-     * Formats and displays a task unmarked as done.
-     *
-     * @param unmarkedTask The task that was unmarked.
-     * @return Formatted message.
-     */
-    public String formatTaskUnmarked(Task unmarkedTask) {
-        String message = "OK, I've marked this task as not done yet:"
-                + System.lineSeparator()
-                + unmarkedTask
-                + System.lineSeparator();
-
-        System.out.print(message);
-        return message;
+        return message.toString();
     }
 
     /**
@@ -196,10 +175,12 @@ public class Ui {
      *
      * @param message Error message to print.
      */
-    public void showError(String message) {
+    public String showError(String message) {
+        String output = "[ERROR] " + message;
         System.out.print(ANSI_RED);
-        System.out.println("[ERROR] " + message);
+        System.out.println(output);
         System.out.print(ANSI_RESET);
+        return output;
     }
 
     /**

--- a/src/test/java/dyuque/DyuqueExecuteCommandTest.java
+++ b/src/test/java/dyuque/DyuqueExecuteCommandTest.java
@@ -21,19 +21,20 @@ public class DyuqueExecuteCommandTest {
         boolean goodbyeShown = false;
         int lineCount = 0;
 
-        @Override
         public void showMessage(String message) {
             lastMessage = message;
         }
 
         @Override
-        public void showError(String message) {
+        public String showError(String message) {
             lastError = message;
+            return message;
         }
 
         @Override
-        public void showGoodbye() {
+        public String showGoodbye() {
             goodbyeShown = true;
+            return null;
         }
 
         @Override


### PR DESCRIPTION
Dyuque did not previously support reverting state-changing commands, so it was not possible to undo accidental state changes such as add, delete, mark, or unmark.

Let's introduce a lightweight undo mechanism without refactoring the existing enum-based command architecture:

- Add UNDO command to Dyuque.Command and update Parser to recognize it

- Introduce a private UndoAction functional interface and an ArrayDeque<UndoAction> undoStack in Dyuque to track inverse actions

- Push an inverse UndoAction onto the stack after each successful state-changing operation (add, delete, mark, unmark)

- Implement handleUndo() to pop and execute the most recent inverse action, restoring the previous TaskList state

- Extend TaskList with minimal helper methods (e.g., insert, get) required to restore deleted tasks and previous mark states

Design decisions:
- Store inverse operations instead of raw CommandArgumentPair to avoid reparsing and index drift issues

- Keep undo logic in Dyuque to preserve separation between orchestration and domain logic

- Follow LIFO stack discipline to ensure consistent step-back behavior

Benefits:
- Enables safe rollback of recent user actions
- Avoids heavy refactoring into full command objects
- Keeps changes localized and minimally invasive
- Maintains current architecture while improving usability